### PR TITLE
Sym rewrite

### DIFF
--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -188,12 +188,12 @@ void CharToTransVec(char ch, std::vector<AffineTransform> &trans) {
   }
 
   if (ch == '+') {
-    trans = SymmetryGroupFromString("D4+");
+    trans = SymmetryGroupFromString("C4");
     return;
   }
 
-  if (ch == '/' || ch == '\\') {
-    trans = SymmetryGroupFromString("D2\\");
+  if (ch == '/') {
+    trans = SymmetryGroupFromString("D2/");
     return;
   }
   // For 180 degree symetrical
@@ -346,24 +346,7 @@ void ReadParams(const std::string& fname, std::vector<CatalystInput> &catalysts,
 
       
       if (elems[0] == symmetry) {
-        std::string symmetryString = "";
-        // reverse-compatibility reasons.
-        if (elems[1] == "horizontal") {
-          symmetryString = "D2|odd";
-        } else if (elems[1] == "horizontaleven") {
-          symmetryString = "D2|even";
-        } else if (elems[1] == "diagonal") {
-          symmetryString = "D2/"; // I think this was the way that it worked before?
-        } else if (elems[1] == "rotate180") {
-          symmetryString = "C2";
-        } else if (elems[1] == "rotate180evenx") {
-          symmetryString = "C2horizontaleven";
-        } else if (elems[1] == "rotate180evenboth") {
-          symmetryString = "C2evenboth";
-        } else {
-          symmetryString = elems[1];
-        }
-        auto symGroup = SymmetryGroupFromString(symmetryString);
+        auto symGroup = SymmetryGroupFromString(elems[1]);
         if(symGroup.size() == 0){
           std::cout << "Couldn't parse symmetry option " << symmetryString << std::endl;
           exit(0);

--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -348,7 +348,7 @@ void ReadParams(const std::string& fname, std::vector<CatalystInput> &catalysts,
       if (elems[0] == symmetry) {
         auto symGroup = SymmetryGroupFromString(elems[1]);
         if(symGroup.size() == 0){
-          std::cout << "Couldn't parse symmetry option " << symmetryString << std::endl;
+          std::cout << "Couldn't parse symmetry option " << elems[1] << std::endl;
           exit(0);
         }
         params.symmetryChain = SymmetryChainFromGroup(symGroup);

--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -165,14 +165,6 @@ public:
 };
 
 void CharToTransVec(char ch, std::vector<AffineTransform> &trans) {
-  AffineTransform Identity;
-  AffineTransform ReflectAcrossX(1,0,0,-1);
-  AffineTransform ReflectAcrossY(-1,0,0,1);
-  AffineTransform ReflectAcrossYeqX(0,1,1,0);
-  AffineTransform ReflectAcrossYeqNegXP1(0,-1,-1,0);
-  AffineTransform Rotate90(0,-1,1,0);
-  AffineTransform Rotate270(0,1,-1,0);
-  AffineTransform Rotate180OddBoth(-1,0,0,-1);
 
   if (ch == '.'){
     trans = SymmetryGroupFromString("C1");
@@ -198,10 +190,10 @@ void CharToTransVec(char ch, std::vector<AffineTransform> &trans) {
   }
   // For 180 degree symetrical
   if (ch == 'x') {
-    trans.push_back(Identity);
-    trans.push_back(Rotate90);
-    trans.push_back(ReflectAcrossX);
-    trans.push_back(ReflectAcrossYeqX);
+    trans.push_back(AffineTransform());
+    trans.push_back(AffineTransform(LinearTransform::Rotate90));
+    trans.push_back(AffineTransform(LinearTransform::FlipAcrossX));
+    trans.push_back(AffineTransform(LinearTransform::FlipAcrossYEqX));
     return;
   }
 

--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -75,7 +75,7 @@ public:
   int searchArea[4]{};
   int maxW;
   int maxH;
-  std::vector<AffineTransform> symmetryChain;
+  StaticSymmetry symmetryEnum;
 
   std::vector<std::string> targetFilter;
   std::vector<int> filterdx;
@@ -83,7 +83,7 @@ public:
   std::vector<int> filterGen;
 
   //modification
-  std::vector<std::string> filterGroups;
+  std::vector<StaticSymmetry> filterGroups;
   // number of generations: if catalysts are destroyed, filters must be met within this many generations afterward or earlier.
   int stopAfterCatsDestroyed; 
 
@@ -108,7 +108,7 @@ public:
     outputFile = "results.rle";
     maxW = -1;
     maxH = -1;
-    symmetryChain = {};
+    symmetryEnum = StaticSymmetry::C1;
     maxCatSize = -1;
     fullReportFile = "";
     
@@ -164,28 +164,90 @@ public:
   }
 };
 
+StaticSymmetry SymmetryEnumFromString(const std::string & name){
+  std::string start = name.substr(0,2);
+  std::string rest = name.substr(2);
+    if (start == "D2"){
+    if (rest == "-" or rest == "vertical"){
+      return StaticSymmetry::D2AcrossX;
+    } else if (rest == "-even" or rest == "verticaleven"){
+      return StaticSymmetry::D2AcrossXEven;
+    } else if (rest == "|" or rest == "horizontal"){
+      return StaticSymmetry::D2AcrossY;
+    } else if (rest == "|even" or rest == "horizontaleven"){
+      return StaticSymmetry::D2AcrossYEven;
+    } else if ( rest == "/" or rest == "/odd") {
+      return StaticSymmetry::D2negdiagodd;
+    } else if ( rest == "\\" or rest == "\\odd") {
+      return StaticSymmetry::D2diagodd;
+    }
+  } else if (start == "C2") {
+    if (rest == "" or rest == "_1"){
+      return StaticSymmetry::C2;
+    } else if (rest == "even" or rest == "_4"){
+      return StaticSymmetry::C2even;
+    } else if (rest == "horizontaleven" or rest == "|even"){
+      return StaticSymmetry::C2horizontaleven;
+    } else if (rest == "verticaleven" or rest == "-even" or rest == "_2"){
+      return StaticSymmetry::C2verticaleven;
+    }
+  } else if (start == "C4"){
+    if (rest == "" or rest == "_1"){
+      return StaticSymmetry::C4;
+    } else if (rest == "even" or rest == "_4") {
+      return StaticSymmetry::C4even;
+    }
+  } else if (start == "D4"){
+    std::string evenOddInfo = rest.substr(1);
+    if (rest[0] == '+' or (rest.size() > 1 and rest[1] == '+')){
+      if(evenOddInfo == "" or rest == "_+1"){
+        return StaticSymmetry::D4;
+      } else if (evenOddInfo == "even" or rest == "_+4"){
+        return StaticSymmetry::D4even;
+      } else if (  evenOddInfo == "verticaleven" or evenOddInfo == "-even" or rest == "_+2") {
+        return StaticSymmetry::D4verticaleven;
+      } else if ( evenOddInfo == "horizontaleven" or evenOddInfo == "|even" ) {
+        return StaticSymmetry::D4horizontaleven;
+      }
+    } else if (rest[0] == 'x' or (rest.size() > 1 and rest[1] == 'x')) {
+      if (evenOddInfo == "" or rest == "_x1"){
+        return StaticSymmetry::D4diag;
+      } else if (evenOddInfo == "even" or rest == "_x4"){
+        return StaticSymmetry::D4diageven;
+      }
+    }
+  } else if (start == "D8") {
+    if (rest == "" or rest == "_1"){
+      return StaticSymmetry::D8;
+    } else if (rest == "even" or rest == "_4"){
+      return StaticSymmetry::D8even;
+    }
+  }
+  return StaticSymmetry::C1;
+}
+
 void CharToTransVec(char ch, std::vector<AffineTransform> &trans) {
 
   if (ch == '.'){
-    trans = SymmetryGroupFromString("C1");
+    trans = SymmetryGroupFromEnum(StaticSymmetry::C1);
     return;
   } if (ch == '|') {
-    trans = SymmetryGroupFromString("D2|");
+    trans =  SymmetryGroupFromEnum(StaticSymmetry::D2AcrossY);
     return;
   }
 
   if (ch == '-') {
-    trans = SymmetryGroupFromString("D2-");
+    trans =  SymmetryGroupFromEnum(StaticSymmetry::D2AcrossX);
     return;
   }
 
   if (ch == '+') {
-    trans = SymmetryGroupFromString("C4");
+    trans =  SymmetryGroupFromEnum(StaticSymmetry::C4);
     return;
   }
 
   if (ch == '/') {
-    trans = SymmetryGroupFromString("D2/");
+    trans =  SymmetryGroupFromEnum(StaticSymmetry::D2negdiagodd);
     return;
   }
   // For 180 degree symetrical
@@ -198,11 +260,10 @@ void CharToTransVec(char ch, std::vector<AffineTransform> &trans) {
   }
 
   if (ch == '*') {
-    trans=SymmetryGroupFromString("D8");
+    trans=SymmetryGroupFromEnum(StaticSymmetry::D8);
     return;
   }
 }
-
 
 
 void ReadParams(const std::string& fname, std::vector<CatalystInput> &catalysts,
@@ -316,13 +377,14 @@ void ReadParams(const std::string& fname, std::vector<CatalystInput> &catalysts,
 
         // modification
         if ( elems.size() >= 6 && (elems[5].at(0) == 'D' || elems[5].at(0) == 'C') ) {
-          if(SymmetryGroupFromString(elems[5]).size() == 0){
+          if ( elems[5] == "C1" || SymmetryEnumFromString(elems[5]) != StaticSymmetry::C1){
+            params.filterGroups.push_back(SymmetryEnumFromString(elems[5]));
+          } else {
             std::cout << "filter symmetry group " << elems[5] << " not understood." << std::endl;
             exit(0);
           }
-          params.filterGroups.push_back(elems[5]);
         } else {
-          params.filterGroups.push_back("C1");
+          params.filterGroups.push_back(StaticSymmetry::C1);
         }
 
       }
@@ -338,12 +400,12 @@ void ReadParams(const std::string& fname, std::vector<CatalystInput> &catalysts,
 
       
       if (elems[0] == symmetry) {
-        auto symGroup = SymmetryGroupFromString(elems[1]);
-        if(symGroup.size() == 0){
+        if ( elems[1] == "C1" || SymmetryEnumFromString(elems[1]) != StaticSymmetry::C1){
+          params.symmetryEnum = SymmetryEnumFromString(elems[1]);
+        } else {
           std::cout << "Couldn't parse symmetry option " << elems[1] << std::endl;
           exit(0);
         }
-        params.symmetryChain = SymmetryChainFromGroup(symGroup);
       }
 
       if (elems[0] == stopAfterCatsDestroyed){
@@ -649,8 +711,8 @@ void XYStartGenPerState(const std::vector<LifeTarget> &targets,
 
       for (int y = 0; y < 64; y++) {
         LifeState state;
-        state.JoinWSymChain(states[i], x, y, params.symmetryChain);
-        state.JoinWSymChain(pat, params.symmetryChain);
+        state.JoinWSymChain(states[i], x, y, params.symmetryEnum);
+        state.JoinWSymChain(pat, params.symmetryEnum);
         int j;
 
         for (j = 0; j < params.maxGen + 1; j++) {
@@ -724,7 +786,7 @@ void XYStartGenPerState(const std::vector<LifeTarget> &targets,
 void PreIteratePat(LifeState &pat, std::vector<LifeState> &preIterated,
                    const SearchParams &params) {
   LifeState workspace;
-  workspace.JoinWSymChain(pat, params.symmetryChain);
+  workspace.JoinWSymChain(pat, params.symmetryEnum);
 
   for (int i = 0; i < params.maxGen + 5; i++) {
     preIterated.push_back(workspace);
@@ -1069,7 +1131,7 @@ public:
     // modification
     for (int i = 0; i < params.targetFilter.size(); i++){
       targetFilterLists.push_back(std::vector<LifeTarget>({}));
-      for ( AffineTransform trans : SymmetryGroupFromString(params.filterGroups[i])){
+      for ( AffineTransform trans : SymmetryGroupFromEnum(params.filterGroups[i])){
         targetFilterLists[i].push_back(LifeTarget::Parse(params.targetFilter[i].c_str(),
                                         params.filterdx[i], params.filterdy[i], trans));
         // debugging purposes
@@ -1284,8 +1346,8 @@ public:
 
   void PutStartState(LifeState &workspace, Configuration &conf) {
     workspace.Clear();
-    workspace.JoinWSymChain(conf.state, params.symmetryChain);
-    workspace.JoinWSymChain(pat, params.symmetryChain);
+    workspace.JoinWSymChain(conf.state, params.symmetryEnum);
+    workspace.JoinWSymChain(pat, params.symmetryEnum);
   }
 
   // modified
@@ -1342,7 +1404,7 @@ public:
       return -1; // Temporary fix
 
     LifeState workspace;
-    workspace.JoinWSymChain(conf.state, params.symmetryChain);
+    workspace.JoinWSymChain(conf.state, params.symmetryEnum);
     workspace.Join(preIterated[conf.minIter]);
     workspace.gen = conf.minIter;
 
@@ -1388,7 +1450,7 @@ public:
     LifeState workspace;
     // if reportAll - ignore filters and update fullReport
     if (reportAll) {
-      workspace.JoinWSymChain(conf.state, params.symmetryChain);
+      workspace.JoinWSymChain(conf.state, params.symmetryEnum);
       catalysts.Copy(workspace);
 
       PutStartState(workspace, conf);
@@ -1408,7 +1470,7 @@ public:
     if (params.stopAfterCatsDestroyed > 0){
 
       LifeState checkCatsDestroyed;
-      checkCatsDestroyed.JoinWSymChain(conf.state, params.symmetryChain);
+      checkCatsDestroyed.JoinWSymChain(conf.state, params.symmetryEnum);
       PutStartState(checkCatsDestroyed, conf);
       checkCatsDestroyed.Step(successtime);
       int absence = 0;
@@ -1442,7 +1504,7 @@ public:
 
     // If all filters validated update results
     workspace.Clear();
-    workspace.JoinWSymChain(conf.state, params.symmetryChain);
+    workspace.JoinWSymChain(conf.state, params.symmetryEnum);
     catalysts.Copy(workspace);
 
     PutStartState(workspace, conf);

--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -323,14 +323,14 @@ void ReadParams(const std::string& fname, std::vector<CatalystInput> &catalysts,
         params.filterdy.push_back(atoi(elems[4].c_str()));
 
         // modification
-        if( elems.size() == 5){
-          params.filterGroups.push_back("C1");
-        } else if ( elems[5][0] == 'D' || elems[5][0] == 'C' ) {
+        if ( elems.size() >= 6 && (elems[5].at(0) == 'D' || elems[5].at(0) == 'C') ) {
           if(SymmetryGroupFromString(elems[5]).size() == 0){
             std::cout << "filter symmetry group " << elems[5] << " not understood." << std::endl;
             exit(0);
           }
           params.filterGroups.push_back(elems[5]);
+        } else {
+          params.filterGroups.push_back("C1");
         }
 
       }

--- a/LifeAPI.h
+++ b/LifeAPI.h
@@ -181,14 +181,16 @@ std::vector<AffineTransform> SymmetryGroupFromString(const std::string & groupNa
 
   std::string start = groupName.substr(0,2);
   std::string rest = groupName.substr(2);
+
+
   if (start == "C1" or start == "no"){
     return {Identity};
   } else if (start == "D2"){
-    if (rest == "-" or rest == "vertical" or rest == "verticalodd" or rest == "-odd"){
+    if (rest == "-" or rest == "vertical"){
       return {Identity, ReflectAcrossX};
     } else if (rest == "-even" or rest == "verticaleven"){
       return {Identity, ReflectAcrossXEven};
-    } else if (rest == "|" or rest == "horizontal" or rest == "horizontalodd" or rest == "|odd"){
+    } else if (rest == "|" or rest == "horizontal"){
       return {Identity, ReflectAcrossY};
     } else if (rest == "|even" or rest == "horizontaleven"){
       return {Identity, ReflectAcrossYEven};
@@ -198,44 +200,44 @@ std::vector<AffineTransform> SymmetryGroupFromString(const std::string & groupNa
       return {Identity, ReflectAcrossYeqX};
     }
   } else if (start == "C2") {
-    if (rest == "odd" or rest == "oddboth" or rest == "bothodd" or rest == ""){
+    if (rest == "" or rest == "_1"){
       return {Identity,Rotate180OddBoth};
-    } else if (rest == "even" or rest == "botheven" or rest == "evenboth"){
+    } else if (rest == "even" or rest == "_4"){
       return {Identity,Rotate180EvenBoth};
     } else if (rest == "horizontaleven" or rest == "|even"){
       return {Identity,Rotate180EvenHorizontal};
-    } else if (rest == "verticaleven" or rest == "-even"){
+    } else if (rest == "verticaleven" or rest == "-even" or rest == "_2"){
       return {Identity, Rotate180EvenVertical};
     }
   } else if (start == "C4"){
-    if (rest == "" or rest == "odd" or rest == "oddboth" or rest == "bothodd"){
+    if (rest == "" or rest == "_1"){
       return {Identity, Rotate90, Rotate180OddBoth, Rotate270};
-    } else if (rest == "even" or rest =="evenboth" or rest == "botheven") {
+    } else if (rest == "even" or rest == "_4") {
       return {Identity, Rotate90Even, Rotate180EvenBoth, Rotate270Even};
     }
   } else if (start == "D4"){
     std::string evenOddInfo = rest.substr(1);
-    if (rest[0] == '+'){
-      if(evenOddInfo == "" or evenOddInfo == "odd" or evenOddInfo == "oddboth" or evenOddInfo == "bothodd"){
+    if (rest[0] == '+' or (rest.size() > 1 and rest[1] == '+')){
+      if(evenOddInfo == "" or rest == "_+1"){
         return {Identity, ReflectAcrossX, ReflectAcrossY, Rotate180OddBoth};
-      } else if (evenOddInfo == "even" or evenOddInfo =="evenboth" or evenOddInfo == "botheven"){
+      } else if (evenOddInfo == "even" or rest == "_+4"){
         return {Identity, ReflectAcrossXEven, Rotate180EvenBoth, ReflectAcrossYEven};
-      } else if ( evenOddInfo == "verticaleven" or evenOddInfo == "-even") {
+      } else if (  evenOddInfo == "verticaleven" or evenOddInfo == "-even" or rest == "_+2") {
         return {Identity, ReflectAcrossXEven, Rotate180EvenVertical, ReflectAcrossY}; // should this be evenX or evenY?
-      } else if ( evenOddInfo == "horizontaleven" or evenOddInfo == "|even") {
+      } else if ( evenOddInfo == "horizontaleven" or evenOddInfo == "|even" ) {
         return {Identity, ReflectAcrossX, Rotate180EvenHorizontal, ReflectAcrossYEven}; // should this be evenX or evenY?
       }
-    } else if (rest[0] == 'x') {
-      if (evenOddInfo == "odd" or evenOddInfo == "oddboth" or evenOddInfo == ""){
+    } else if (rest[0] == 'x' or (rest.size() > 1 and rest[1] == 'x')) {
+      if (evenOddInfo == "odd" or rest == "_x1"){
         return {Identity, ReflectAcrossYeqX, Rotate180OddBoth,ReflectAcrossYeqNegXP1};
-      } else if (evenOddInfo == "even" or evenOddInfo == "evenboth"){
+      } else if (evenOddInfo == "even" or rest == "_x4"){
         return {Identity, ReflectAcrossYeqX, Rotate180EvenBoth, ReflectAcrossYeqNegX};
       }
     }
   } else if (start == "D8") {
-    if (rest == "odd" or rest == "oddboth" or rest == ""){
+    if (rest == "" or rest == "_1"){
       return {Identity, ReflectAcrossX, ReflectAcrossY, Rotate90, Rotate270, Rotate180OddBoth, ReflectAcrossYeqX, ReflectAcrossYeqNegXP1};
-    } else if (rest == "even" or rest == "evenboth"){
+    } else if (rest == "even" or rest == "_4"){
       return {Identity, ReflectAcrossXEven, ReflectAcrossYEven, Rotate90Even, Rotate270Even, Rotate180EvenBoth, ReflectAcrossYeqX, ReflectAcrossYeqNegX};
     }
   }

--- a/LifeAPI.h
+++ b/LifeAPI.h
@@ -228,7 +228,7 @@ std::vector<AffineTransform> SymmetryGroupFromString(const std::string & groupNa
         return {Identity, ReflectAcrossX, Rotate180EvenHorizontal, ReflectAcrossYEven}; // should this be evenX or evenY?
       }
     } else if (rest[0] == 'x' or (rest.size() > 1 and rest[1] == 'x')) {
-      if (evenOddInfo == "odd" or rest == "_x1"){
+      if (evenOddInfo == "" or rest == "_x1"){
         return {Identity, ReflectAcrossYeqX, Rotate180OddBoth,ReflectAcrossYeqNegXP1};
       } else if (evenOddInfo == "even" or rest == "_x4"){
         return {Identity, ReflectAcrossYeqX, Rotate180EvenBoth, ReflectAcrossYeqNegX};

--- a/LifeAPI.h
+++ b/LifeAPI.h
@@ -920,30 +920,30 @@ void LifeState::Transform(AffineTransform transform) {
   if ( transform.matrix == 3 || transform.matrix == 5){
     // rotate 270 and flipYEqX become ReflectX and Identity.
     Transpose(false);
-    //transform = transform.Compose(AffineTransform(LinearTransform::FlipAcrossYEqX));
+    transform = transform.Compose(AffineTransform(LinearTransform::FlipAcrossYEqX));
 
 
   } else if ( transform.matrix == 1 || transform.matrix == 7) {
     //rotate 90 and flipYEqNegXP1 become ReflectY and Identity.
     Transpose(true);// this is has [0, -1, -1, 0] as matrix, [-1, -1] for translation.
     Move(1,1);
-    //transform = transform.Compose(AffineTransform(LinearTransform::FlipAcrossYEqNegXP1));
+    transform = transform.Compose(AffineTransform(LinearTransform::FlipAcrossYEqNegXP1));
 
   }
 
   if(transform.matrix == 4 || transform.matrix == 2 ) {
     FlipAcrossX();
-    //transform = transform.Compose(AffineTransform(LinearTransform::FlipAcrossX));
+    transform = transform.Compose(AffineTransform(LinearTransform::FlipAcrossX));
 
   }
 
   if(transform.matrix == 6 ) {
     FlipAcrossY();
-    //transform = transform.Compose(AffineTransform(LinearTransform::FlipAcrossY));
+    transform = transform.Compose(AffineTransform(LinearTransform::FlipAcrossY));
 
   }
 
-  //assert(transform.matrix == Rotate0);
+  assert(transform.matrix == Rotate0);
 
   Move(transform.transl.first, transform.transl.second);
 

--- a/README.md
+++ b/README.md
@@ -26,28 +26,30 @@ See `1.in` for an example.
 
 The option delimiter is `" "` - i.e. space. 
 
-| Line                  | Parameter             | Description                                                            |
-|-----------------------|-----------------------|------------------------------------------------------------------------|
-| `max-gen`             | `n`                   | Overall maximum generation                                             |
-| `start-gen`           | `n`                   | The min gen the first encounter must happen by                         |
-| `last-gen`            | `n`                   | The max gen the _first_ encounter is allowed                           |
-| `num-catalyst`        | `n`                   | The number of catalyst to place                                        |
-| `stable-interval`     | `n`                   | Gens the catalysts must remain untouched to be considered stable       |
-| `search-area`         | `x y w h`             | Search area                                                            |
-| `pat`                 | `rle`                 | The active pattern                                                     |
-|                       | `(dx dy)`             | Optional offset                                                        |
-| `cat `                | `rle`                 | A catalyst                                                             |
-|                       | `max-active`          | Number of generations in a row the catalyst may be missing             |
-|                       | `dx dy`               | Offset to centre the catalyst (typically negative)                     |
-|                       | `symmetries-char`     | Character denoting the symmetry of the catalyst                        |
-|                       | `(forbidden rle x y)` | Optional forbidden pattern around the catalyst                         |
-| `output`              | `filename`            | Output filename                                                        |
-| `filter`              | `gen rle dx dy`       | Filter that must be matched for the solution to be accepted            |
-| `filter`              | `min-max rle dx dy`   | Filter in a range of generations.                                      |
-| `full-report`         | `filename`            | Output filename for solutions ignoring all pattern filters             |
-| `max-category-size`   | `n`                   | Maximum output row length before more solutions are dropped            |
-| `fit-in-width-height` | `w h`                 | Only allow solutions where all catalysts fit in a `w` by `h` rectangle |
-| `symmetry`            |                       | See below                                                              |
+| Line                        | Parameter                | Description                                                            |
+|-----------------------------|--------------------------|------------------------------------------------------------------------|
+| `max-gen`                   | `n`                      | Overall maximum generation                                             |
+| `start-gen`                 | `n`                      | The min gen the first encounter must happen by                         |
+| `last-gen`                  | `n`                      | The max gen the _first_ encounter is allowed                           |
+| `num-catalyst`              | `n`                      | The number of catalyst to place                                        |
+| `stable-interval`           | `n`                      | Gens the catalysts must remain untouched to be considered stable       |
+| `search-area`               | `x y w h`                | Search area                                                            |
+| `pat`                       | `rle`                    | The active pattern                                                     |
+|                             | `(dx dy)`                | Optional offset                                                        |
+| `cat `                      | `rle`                    | A catalyst                                                             |
+|                             | `max-active`             | Number of generations in a row the catalyst may be missing             |
+|                             | `dx dy`                  | Offset to centre the catalyst (typically negative)                     |
+|                             | `symmetries-char`        | Character denoting the symmetry of the catalyst                        |
+|                             | `(forbidden rle x y)`    | Optional forbidden pattern around the catalyst                         |
+| `output`                    | `filename`               | Output filename                                                        |
+| `filter`                    | `gen rle dx dy`          | Filter that must be matched for the solution to be accepted            |
+| `filter`                    | `min-max rle dx dy`      | Filter in a range of generations.                                      |
+| `filter`                    | `min-max rle dx dy sym`  | Filter with symmetry (see below)                                       |
+| `full-report`               | `filename`               | Output filename for solutions ignoring all pattern filters             |
+| `max-category-size`         | `n`                      | Maximum output row length before more solutions are dropped            |
+| `fit-in-width-height`       | `w h`                    | Only allow solutions where all catalysts fit in a `w` by `h` rectangle |
+| `symmetry`                  |                          | See below                                                              |
+| `stop-after-cats-destroyed` | `n`                      | Filters must be met n generations after catalyst destruction or sooner |
 
 
 
@@ -74,7 +76,16 @@ an example.
 **Filters**: one can use several filters. Every filter will be
 checked if successful catalyst was found. Each filter will select
 for patterns matching the live cells in `rle` and dead cells in close
-proximity neighbourhood to the live cells in `rle`.
+proximity neighbourhood to the live cells in `rle`. Filters also
+accept a symmetry group: one of the transformed images of the
+`rle` must appear. (Intended for searching for oscillators that
+flip every half period: this way, one search and one filter covers
+both re-occurrance and the various the oscillator could flip.)
+
+**Stop After Catalysts Destroyed**: if the catalysts all recover,
+only check filters out to n generations after the first
+catalyst is destroyed. (This cuts down on false positives 
+when searching for oscillators.)
 
 <!-- Combining Results -->
 <!-- --- -->

--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ The option delimiter is `" "` - i.e. space.
 **Encounter**: An active cell from the input pattern is present in
 the immediate neighbourhood of the catalyst.
 
-**Catalyst Symmetry**: A character specifying what symmetries are
+**Catalyst Symmetry**: A character specifying what transformations are
 applied to the catalyst:
 - `|` mirror by y.
 - `-` mirror by x.
-- `+` mirror by x, y and both. 
-- `/` diagonal mirror.
-- `x` make for 180 degree symmetrical catalysts.
+- `+` all 90 degree rotations, for D2- or D2/ invariant catalysts (eg boat).
+- `/` diagonal mirror
+- `x` for 180 degree symmetrical catalysts.
 - `*` all 8 transformations.
 
 **Forbidden**: Will search for `rle` in the same location as the
@@ -72,9 +72,9 @@ may have several forbidden patterns per catalyst. See `3.in` for
 an example.
 
 **Filters**: one can use several filters. Every filter will be
-checked if successful catalyst was found. Each filter will assume live
-cells in `rle` and dead cell in close proximity neighbourhood to the
-pattern in `rle`.
+checked if successful catalyst was found. Each filter will select
+for patterns matching the live cells in `rle` and dead cells in close
+proximity neighbourhood to the live cells in `rle`.
 
 <!-- Combining Results -->
 <!-- --- -->
@@ -119,15 +119,25 @@ Symmetric Searches
 
 `symmetry s`
 
-Automatically apply the symmetry `s` to the active pattern and
-catalysts. The lines of symmetry are always `x=0` and `y=0`, and
-so if you want a different offset you will have to change the `dx dy`
-parameters of the active pattern.
+Automatically apply the symmetry `s` to the active pattern and catalysts. Options:
+- D2 symmetries: `D2|` (reflect across x = 0), `D2-` (y = 0), `D2\` (y=x) and `D2/` (y=-x)
+- C2 symmetries: `C2_1` (bounding box odd by odd), `C2_2` (odd by even), `C2_4` (even by even)
+- C4 symmetries: `C4_1`, (odd by odd) `C4_4` (even by even)
+- D4 symmetries: `D4_+1`, `D4_+2` (odd by even),`D4_+4`, `D4_x1`, and `D4_x4`
+- D8 symmetries: `D8_1` and `D8_4`
 
-Options are:
-- `horizontal`
-- `horizontaleven`
-- `diagonal`
-- `diagonalevenx` 
-- `diagonalevenboth`
- 
+
+The options D2 follow [LLS](https://gitlab.com/OscarCunningham/logic-life-search), while the rest of the symmetries follow [Catagolue](https://catagolue.hatsya.com/census). [LifeWiki](https://conwaylife.com/wiki/Static_symmetry) has a more in-depth explanation, though the notation there is slightly
+different. (They choose `C2_2` to be even by odd not odd by even).
+
+There's LLS-inspired alternatives for the other groups: 
+- D2 symmetries: as above
+- C2 symmetries: `C2 C2even C2|even C2-even`
+- C4 symmetries: `C4 C4even`
+- D4 symmetries: `D4+ D4+|even D4+-even D4+|even D4x D4xeven`
+- D8 symmetries: `D8 D8even`
+
+Here, things default to odd transformations, ie ones that fix the cell at (0,0);`verticaleven` and `horizontaleven` (referring to bounding
+box dimensions) are recognized as equivalent to `-even` and `|even`,
+respectively.
+

--- a/README.md
+++ b/README.md
@@ -78,9 +78,10 @@ checked if successful catalyst was found. Each filter will select
 for patterns matching the live cells in `rle` and dead cells in close
 proximity neighbourhood to the live cells in `rle`. Filters also
 accept a symmetry group: one of the transformed images of the
-`rle` must appear. (Intended for searching for oscillators that
-flip every half period: this way, one search and one filter covers
-both re-occurrance and the various the oscillator could flip.)
+`rle` must appear. See the symmetric searches section for syntax.
+(Intended for searching for oscillators that flip every half period:
+ this way, one search and one filter covers both re-occurrance
+ and the various the oscillator could flip.)
 
 **Stop After Catalysts Destroyed**: if the catalysts all recover,
 only check filters out to n generations after the first

--- a/sym.in
+++ b/sym.in
@@ -6,7 +6,7 @@ stable-interval 15
 
 search-area -1 -18 18 36
 
-symmetry rotate180evenx
+symmetry C2horizontaleven
 pat 2bo$b3o$o3bo$b3o$2bo! 1 1
 output sym.rle
 


### PR DESCRIPTION
I rewrote linear transformation implementation using enums. Groups are also now passed around as enums, and only converted into a list of transformations in the JoinWSymChain function. Also brought the symmetry syntax up to date.