### PR TITLE
shifted targets now arrays

### DIFF
--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -1441,7 +1441,9 @@ public:
 
     std::vector<LifeState> masks(catalysts.size());
     for (unsigned s = 0; s < catalysts.size(); s++) {
-      masks[s] = config.state.Convolve(catalysts[s].reactionMask) | ~bounds;
+      LifeState rotatedCat = catalysts[s].state;
+      rotatedCat.Transform(Rotate180OddBoth);
+      masks[s] = config.state.Convolve(rotatedCat) | ~bounds;
     }
 
     std::vector<std::array<LifeTarget, MAX_PERIOD>> shiftedTargets(params.numCatalysts);

--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -1338,7 +1338,7 @@ public:
           // }
         }
 
-        if (succeeded && (params.maxJunk != -1 || junk.GetPop() <= params.maxJunk)) {
+        if (succeeded && (params.maxJunk == -1 || junk.GetPop() <= params.maxJunk)) {
           filterPassed[k] = true;
 
           // If this was an OR filter, consider all the other OR filters passed

--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -738,7 +738,6 @@ struct Configuration {
   std::array<int, MAX_CATALYSTS> curx;
   std::array<int, MAX_CATALYSTS> cury;
   std::array<int, MAX_CATALYSTS> curs;
-  std::array<int, MAX_CATALYSTS> placementGens;
   LifeState state;
   LifeState catalystsState;
   LifeState startingCatalysts;
@@ -1521,7 +1520,6 @@ public:
               newConfig.curx[config.count] = newPlacement.first;
               newConfig.cury[config.count] = newPlacement.second;
               newConfig.curs[config.count] = s;
-              newConfig.placementGens[config.count] = g;
               if (catalysts[s].transparent)
                 newConfig.transparentCount++;
               if (catalysts[s].mustInclude)

--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -720,7 +720,7 @@ std::vector<CatalystData> CatalystData::FromInput(CatalystInput &input) {
         phaseAvoid.RecalculateMinMax();
         result.phaseReactionMask.push_back(phasemask);
         if (result.hasLocus)
-          result.phaseAvoidMask.push_back(phasemask);
+          result.phaseAvoidMask.push_back(phaseAvoid);
 
         tmp.Step();
       }

--- a/CatForce.cpp
+++ b/CatForce.cpp
@@ -629,7 +629,7 @@ public:
   bool hasLocus;
   LifeState locus;
   LifeState locusReactionMask;
-  LifeState locusAvoidMask;
+  //LifeState locusAvoidMask;
   bool transparent;
   bool mustInclude;
   bool checkRecovery;
@@ -702,9 +702,9 @@ std::vector<CatalystData> CatalystData::FromInput(CatalystInput &input) {
       result.locusReactionMask.RecalculateMinMax();
 
       // This is a little janky, it should probably be per phase
-      result.locusAvoidMask = result.reactionMask;
-      result.locusAvoidMask &= ~result.locusReactionMask;
-      result.locusAvoidMask.RecalculateMinMax();
+      //result.locusAvoidMask = result.reactionMask;
+      //result.locusAvoidMask &= ~result.locusReactionMask;
+      //result.locusAvoidMask.RecalculateMinMax();
 
       LifeState tmp = pat;
       for (unsigned j = 0; j < input.period; j++) {
@@ -715,7 +715,7 @@ std::vector<CatalystData> CatalystData::FromInput(CatalystInput &input) {
         phasemask.Transform(Rotate180OddBoth);
         LifeState phaseAvoid = phasemask;
         phasemask &= result.locusReactionMask;
-        phaseAvoid &= result.locusAvoidMask;
+        phaseAvoid &= (~phasemask);
         phasemask.RecalculateMinMax();
         phaseAvoid.RecalculateMinMax();
         result.phaseReactionMask.push_back(phasemask);


### PR DESCRIPTION
Now shifted targets are arrays of life targets, instead of single life targets. CatalystData now has a `std::vector<LifeTarget> targets`, instead of a single target, so we can `std::copy` the LifeTargets from there into shiftedCatalysts (phase shift means we start at `g % period`) and then Move the wanted/unwanted to the right spot. Using arrays means that there's now `MAX_PERIOD`, set to 25. Tested it on `p42.in` and it gives the same result.